### PR TITLE
Adjust UI to make delete dialog centered in the page

### DIFF
--- a/client/src/components/ConfirmDialog.tsx
+++ b/client/src/components/ConfirmDialog.tsx
@@ -1,27 +1,47 @@
 import React from 'react';
 import { Dialog } from 'primereact/dialog';
+import { Button } from 'primereact/button';
 
 export interface ConfirmDialogProps {
-	header?: string;
-	footer?: React.ReactNode;
+	header?: string;	
 	visible: boolean;
 	handleHiding: () => void;
 	content: React.ReactNode;
+	onConfirm: () => void;
 }
 
 const ConfirmDialog = ({
 	header = 'Confirm modal',
-	footer,
 	visible = false,
 	content,
 	handleHiding,
+	onConfirm
 }: ConfirmDialogProps) => {
+
+	const footerContent = (
+		<>
+			<Button
+				label="No"
+				icon="pi pi-times"
+				onClick={handleHiding}
+				autoFocus
+			/>
+			<Button
+				label="Yes"
+				icon="pi pi-check"
+				text
+				onClick={onConfirm}
+				severity="secondary"
+			/>
+		</>
+	);
+
 	return (
 		<Dialog
 			header={header}
 			visible={visible}
 			onHide={handleHiding}
-			footer={footer}
+			footer={footerContent}
 			breakpoints={{ '960px': '75vw' }}
 			style={{ width: '30vw' }}
 		>

--- a/client/src/pages/categories/Categories.tsx
+++ b/client/src/pages/categories/Categories.tsx
@@ -14,6 +14,7 @@ import Spinner from '@components/Spinner';
 import { Message } from 'primereact/message';
 import EditCategory from './EditCategory';
 import CreateCategory from './CreateCategory';
+import ConfirmDialog from '@components/ConfirmDialog';
 
 const Categories = () => {
 	const { data: categories = [], isLoading, isError, error } = useCategories();
@@ -29,6 +30,7 @@ const Categories = () => {
 	const [isEditDialogVisible, setIsEditDialogVisible] = useState(false);
 
 	const { mutate: deleteCategory } = useDeleteCategory();
+	const [isDeleteDialogVisible, setIsDeleteDialogVisible] = useState(false);
 
 	const displayToast = useCallback(
 		(message: string, severity?: ToastMessage['severity']) => {
@@ -44,8 +46,17 @@ const Categories = () => {
 
 	const handleDeleteCategory = (category: Category) => {
 		if (!category) return;
+		setSelectedCategory(category);
+		setIsDeleteDialogVisible(true);
+	}
+
+	const handleConfirmDeleteCategory = (category: Category) => {
+		if (!category) return;
 		deleteCategory(category, {
-			onSuccess: () => displayToast('Category deleted', 'success'),
+			onSuccess: () => {
+				displayToast('Category deleted', 'success');
+				setIsDeleteDialogVisible(false);
+			},
 			onError: () => displayToast('Failed to delete category', 'error'),
 		});
 	};
@@ -123,6 +134,14 @@ const Categories = () => {
 					onUpdateCategory={handleUpdateCategory}
 				/>
 			)}
+			{selectedCategory && (
+				<ConfirmDialog 
+					visible={isDeleteDialogVisible}
+					handleHiding={() => setIsDeleteDialogVisible(false)}
+					content={`Are you sure you want to delete category ${selectedCategory.name}?`}					
+					onConfirm={() => handleConfirmDeleteCategory(selectedCategory)}					
+					/>
+			)}			
 			<CreateCategory
 				isVisible={isCreateDialogVisible}
 				closeDialog={() => setIsCreateDialogVisible(false)}

--- a/client/src/pages/categories/CategoryCard.tsx
+++ b/client/src/pages/categories/CategoryCard.tsx
@@ -6,7 +6,6 @@ import { TooltipOptions } from 'primereact/tooltip/tooltipoptions';
 import { useContext, useMemo } from 'react';
 import { TasksContext } from '@context/TasksProvider';
 import EmptyData from '@components/EmptyData';
-import { confirmPopup, ConfirmPopup } from 'primereact/confirmpopup';
 
 export interface CategoryCardProps {
 	category: Category;
@@ -61,30 +60,17 @@ const CategoryCard = ({ category, onDelete, onEdit }: CategoryCardProps) => {
 				</ul>
 			</ScrollPanel>
 		</>
-	);
-
-	const confirmDelete = (event: React.MouseEvent<HTMLButtonElement>) => {
-		confirmPopup({
-			target: event.currentTarget,
-			message: `Are you sure you want to delete ${category.name} category?`,
-			icon: 'pi pi-info-circle',
-			defaultFocus: 'reject',
-			visible: !hasTasks,
-			accept: () => onDelete(category),
-			reject: () => {},
-		});
-	};
+	);	
 
 	const footer = (
-		<div className="flex flex-row items-center justify-end gap-2">
-			<ConfirmPopup />
+		<div className="flex flex-row items-center justify-end gap-2">			
 			<Button
 				disabled={hasTasks}
 				outlined
 				label="Delete"
 				icon="pi pi-trash"
 				className="text-red-500 border-red-500 dark:text-red-400 dark:border-red-400 "
-				onClick={confirmDelete}
+				onClick={() => onDelete(category)}
 				tooltip={
 					hasTasks
 						? 'Cannot delete category while tasks are assigned.'

--- a/client/src/pages/dashboard/Upcoming.tsx
+++ b/client/src/pages/dashboard/Upcoming.tsx
@@ -17,24 +17,6 @@ const Upcoming = () => {
 	const [visible, setVisible] = useState(false);
 	const [selectedTasks, setSelectedTasks] = useState<Task[] | null>(null);
 
-	const footerContent = (
-		<>
-			<Button
-				label="No"
-				icon="pi pi-times"
-				onClick={() => setVisible(false)}
-				autoFocus
-			/>
-			<Button
-				label="Yes"
-				icon="pi pi-check"
-				text
-				onClick={() => setVisible(false)}
-				severity="secondary"
-			/>
-		</>
-	);
-
 	const checkButton = (
 		<Button
 			icon="pi pi-check"
@@ -98,9 +80,9 @@ const Upcoming = () => {
 					handleHiding={() => {
 						if (!visible) return;
 						setVisible(false);
-					}}
+					} }
 					content={dialogContent}
-					footer={footerContent}
+					onConfirm={() => setVisible(false)}					
 				/>
 			</div>
 		</>

--- a/client/src/tests/CategoryCard.spec.tsx
+++ b/client/src/tests/CategoryCard.spec.tsx
@@ -160,35 +160,24 @@ describe('<CategoryCard />', () => {
 		);
 	});
 
-	it('should render confirmation popup when user clicks on Delete button', async () => {
+	it('should render confirmation dialog when user clicks on Delete button', async () => {
+		const onDeleteSpy = vi.fn();
+
 		render(
 			<TasksContext.Provider value={{ tasks: [] }}>
-				<CategoryCard {...defaultProps} />
+				<CategoryCard {...defaultProps} onDelete={onDeleteSpy}/>
 			</TasksContext.Provider>
 		);
 
 		userEvent.click(getDeleteButton());
+		
 		await waitFor(() =>
-			expect(
-				screen.getByText('Are you sure you want to delete Work category?')
-			).toBeInTheDocument()
-		);
-	});
-
-	it('should call onDelete function when user clicks on Yes from the confirmation popup button', async () => {
-		render(
-			<TasksContext.Provider value={{ tasks: [] }}>
-				<CategoryCard {...defaultProps} />
-			</TasksContext.Provider>
-		);
-
-		userEvent.click(getDeleteButton());
-
-		await waitFor(() => expect(screen.getByText('Yes')).toBeInTheDocument());
-
-		userEvent.click(screen.getByText('Yes'));
-		await waitFor(() =>
-			expect(defaultProps.onDelete).toHaveBeenCalledWith(defaultProps.category)
-		);
-	});
+			expect(onDeleteSpy).toHaveBeenCalledWith({
+				id: 1,
+				name: 'Work',
+				icon: ICON.Briefcase,
+				description: 'Category for work-related tasks',
+			})
+		);	
+	});	
 });

--- a/client/src/tests/ConfirmDialog.spec.tsx
+++ b/client/src/tests/ConfirmDialog.spec.tsx
@@ -2,11 +2,13 @@ import { describe, it, vi, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import ConfirmDialog from '@components/ConfirmDialog';
 import type { ConfirmDialogProps } from '@components/ConfirmDialog';
+import userEvent from '@testing-library/user-event';
 
 const mockDefaultProps: ConfirmDialogProps = {
 	visible: true,
 	handleHiding: vi.fn(),
 	content: 'Are you sure?',
+	onConfirm: vi.fn()
 };
 
 const renderComponent = (props: Partial<ConfirmDialogProps> = {}) =>
@@ -34,9 +36,12 @@ describe('<ConfirmDialog />', () => {
 		).toBeInTheDocument();
 	});
 
-	it('should render footer when it is provided', () => {
-		renderComponent({ footer: <button>Delete</button> });
+	it('should call onConfirm when user confirms operation',  async () => {
+		const onConfirmSpy = vi.fn();
+		renderComponent({ onConfirm: onConfirmSpy })
 
-		expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+		await userEvent.click(screen.getByRole('button', { name: 'Yes' }));
+
+		expect(onConfirmSpy).toHaveBeenCalled();
 	});
 });

--- a/client/src/tests/CreateCategory.spec.tsx
+++ b/client/src/tests/CreateCategory.spec.tsx
@@ -6,8 +6,7 @@ import CreateCategory from '@pages/categories/CreateCategory';
 import userEvent from '@testing-library/user-event';
 import { ICON } from '@shared/types';
 
-const defaultProps: CreateCategoryProps = {
-	category: undefined,
+const defaultProps: CreateCategoryProps = {	
 	isVisible: true,
 	closeDialog: vi.fn(),
 	onCreateCategory: vi.fn(),


### PR DESCRIPTION
### Frontend: Categories

Changing the appearence of the delete popup modal when user clicks on the Delete button to be a centered and unique one, not relative to the button that was clicked.
This change was made to avoid conflicts with the position of the pop-up modal when viewport has its width reduced.

Final UI:

![image](https://github.com/user-attachments/assets/ac42a0c1-2ac0-4f0c-ad7c-c199b26902b7)


