### PR TITLE
Increasing the limit from 10 to 30 category description text

### DIFF
--- a/client/src/pages/categories/Categories.tsx
+++ b/client/src/pages/categories/Categories.tsx
@@ -107,7 +107,7 @@ const Categories = () => {
 				className="my-4 text-teal-500 border-teal-500 dark:text-teal-400 dark:border-teal-400"
 				onClick={() => setIsCreateDialogVisible(true)}
 			/>
-			<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 auto-rows-auto">
+			<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
 				{categories.length > 0 ? (
 					categories.map((category) => (
 						<div key={category.id}>

--- a/client/src/pages/categories/categoryValidation.ts
+++ b/client/src/pages/categories/categoryValidation.ts
@@ -4,7 +4,7 @@ export const categoryValidationSchema = yup.object({
 	name: yup
 		.string()
 		.required('Please provide a category name.')
-		.max(10, 'Category name must not exceed 10 characters.'),
+		.max(30, 'Category name must not exceed 30 characters.'),
 	description: yup
 		.string()
 		.max(100, 'Category description must not exceed 100 characters.'),

--- a/client/src/tests/CreateCategory.spec.tsx
+++ b/client/src/tests/CreateCategory.spec.tsx
@@ -96,18 +96,18 @@ describe('<EditCategory />', () => {
 		});
 	});
 
-	it('should render error message when submitting form with a name field with more than 10 characters', async () => {
+	it('should render error message when submitting form with a name field with more than 30 characters', async () => {
 		const onCreateCategorySpy = vi.fn();
 		renderComponent({ onCreateCategory: onCreateCategorySpy });
 
 		await userEvent.clear(getNameField());
-		await userEvent.type(getNameField(), 'a'.repeat(11));
+		await userEvent.type(getNameField(), 'a'.repeat(31));
 
 		userEvent.click(getSaveButton());
 
 		await waitFor(() => {
 			expect(getNameField()).toHaveAccessibleDescription(
-				'Category name must not exceed 10 characters.'
+				'Category name must not exceed 30 characters.'
 			);
 
 			expect(onCreateCategorySpy).not.toHaveBeenCalled();

--- a/client/src/tests/EditCategory.spec.tsx
+++ b/client/src/tests/EditCategory.spec.tsx
@@ -113,18 +113,18 @@ describe('<EditCategory />', () => {
 		});
 	});
 
-	it('should render error message when submitting form with a name field with more than 10 characters', async () => {
+	it('should render error message when submitting form with a name field with more than 30 characters', async () => {
 		const onUpdateCategorySpy = vi.fn();
 		renderComponent({ onUpdateCategory: onUpdateCategorySpy });
 
 		await userEvent.clear(getNameField());
-		await userEvent.type(getNameField(), 'a'.repeat(11));
+		await userEvent.type(getNameField(), 'a'.repeat(31));
 
 		userEvent.click(getSaveButton());
 
 		await waitFor(() => {
 			expect(getNameField()).toHaveAccessibleDescription(
-				'Category name must not exceed 10 characters.'
+				'Category name must not exceed 30 characters.'
 			);
 
 			expect(onUpdateCategorySpy).not.toHaveBeenCalled();


### PR DESCRIPTION
### Frontend: Categories management

Changing the characters limit in the name of the Category edition and creation forms from 10 to 30. 

Edit form
![image](https://github.com/user-attachments/assets/d6f6e77c-2b50-4188-83b3-370ee0498dd7)

Create form
![image](https://github.com/user-attachments/assets/1bab79c8-761d-4ef7-bbd0-39fa9a330e00)

