### PR TITLE
Moving buttons to menu in the category card header

### DIFF
--- a/client/src/features/categories/components/CategoryCard.tsx
+++ b/client/src/features/categories/components/CategoryCard.tsx
@@ -1,11 +1,12 @@
 import { Card } from 'primereact/card';
 import type { Category, Task } from '@shared/types';
-import { Button } from 'primereact/button';
-import { ScrollPanel } from 'primereact/scrollpanel';
-import { TooltipOptions } from 'primereact/tooltip/tooltipoptions';
-import { useMemo } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import EmptyData from 'src/common/EmptyData';
 import { useTasks } from '@queries';
+import { OverlayPanel } from 'primereact/overlaypanel';
+import { Dialog } from 'primereact/dialog';
+import { Button } from 'primereact/button';
+import { Tooltip } from 'primereact/tooltip';
 
 export interface CategoryCardProps {
 	category: Category;
@@ -16,6 +17,8 @@ export interface CategoryCardProps {
 const CategoryCard = ({ category, onDelete, onEdit }: CategoryCardProps) => {
 	const { id, name, description, icon } = category;
 	const { data: tasks = [] } = useTasks();
+	const [showTasksDialog, setShowTasksDialog] = useState(false);
+	const menuRef = useRef<OverlayPanel>(null);
 
 	const filteredTasks = useMemo(
 		() => tasks.filter((task: Task) => task.categoryId === id),
@@ -24,79 +27,94 @@ const CategoryCard = ({ category, onDelete, onEdit }: CategoryCardProps) => {
 
 	const hasTasks = filteredTasks.length > 0;
 
-	const tooltipOptions: TooltipOptions = useMemo(
-		() => ({
-			position: 'top',
-			event: 'hover',
-			showOnDisabled: true,
-		}),
-		[]
-	);
+	const subtitle = <h3 className="text-xl font-bold text-center">{name}</h3>;
 
 	const header = (
-		<div className="flex flex-col items-center gap-4">
-			<i className={icon} style={{ fontSize: '2rem' }}></i>
-			<h3 className="text-xl">{name}</h3>
+		<div className="flex items-center">
+			<div className="flex flex-grow justify-center items-center ml-5">
+				<i className={icon} style={{ fontSize: '2rem' }}></i>
+			</div>
+			<i
+				className="pi pi-ellipsis-v cursor-pointer text-2xl hover:text-teal-400"
+				onClick={(e) => menuRef.current?.toggle(e)}
+				aria-label="Options"
+			></i>
+			<OverlayPanel ref={menuRef} dismissable>
+				<div className="flex flex-col gap-2">
+					<div
+						className="flex items-center gap-2 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 p-2 rounded"
+						onClick={() => setShowTasksDialog(true)}
+						aria-disabled={hasTasks}
+					>
+						<i className="pi pi-list-check text-black dark:text-white"></i>
+						<span className="text-black dark:text-white">Tasks</span>
+					</div>
+					{hasTasks && (
+						<Tooltip
+							target="#editDeleteTooltipContainer"
+							content="Categories with assigned tasks cannot be edited or deleted."
+						/>
+					)}
+					<div id="editDeleteTooltipContainer" className="flex flex-col gap-2">
+						<div
+							className={`flex items-center gap-2 p-2 rounded ${
+								hasTasks
+									? 'cursor-not-allowed opacity-50'
+									: 'cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700'
+							}`}
+							onClick={!hasTasks ? () => onEdit(category) : undefined}
+						>
+							<i className="pi pi-pencil text-teal-700 dark:text-teal-400"></i>
+							<span className="text-teal-700 dark:text-teal-400">Edit</span>
+						</div>
+						<div
+							className={`flex items-center gap-2 p-2 rounded ${
+								hasTasks
+									? 'cursor-not-allowed opacity-50'
+									: 'cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700'
+							}`}
+							onClick={!hasTasks ? () => onDelete(category) : undefined}
+						>
+							<i className="pi pi-trash text-red-500 dark:text-red-400"></i>
+							<span className="text-red-500 dark:text-red-400">Delete</span>
+						</div>
+					</div>
+				</div>
+			</OverlayPanel>
 		</div>
 	);
 
-	const subTitle = <p className="text-xl text-center">{description}</p>;
-
-	const content = (
+	return (
 		<>
-			<p className="pb-1 font-bold">Current tasks:</p>
-			<ScrollPanel
-				style={{ width: '100%', height: '100px' }}
-				className="border-2 border-gray-200 rounded-lg py-1 dark:border-teal-900"
+			<Card
+				title={header}
+				className="bg-white rounded-lg p-4 h-full justify-between border-2 border-gray-200 dark:border-0"
+				subTitle={subtitle}
+			>
+				<p className="text-xl text-center">{description}</p>
+			</Card>
+			<Dialog
+				header="Tasks"
+				visible={showTasksDialog}
+				onHide={() => setShowTasksDialog(false)}
+				footer={<Button label="Ok" onClick={() => setShowTasksDialog(false)} />}
 			>
 				<ul className="px-2 py-1">
 					{hasTasks ? (
 						filteredTasks.map((task: Task) => (
-							<li key={task.id}>{task.title}</li>
+							<li key={task.id}>
+								<div className="flex items-center gap-2">
+									<i className="pi pi-check-circle"></i>
+									{task.title}
+								</div>
+							</li>
 						))
 					) : (
 						<EmptyData message="No tasks associated with this category." />
 					)}
 				</ul>
-			</ScrollPanel>
+			</Dialog>
 		</>
-	);
-
-	const footer = (
-		<div className="flex flex-row items-center justify-end gap-2">
-			<Button
-				disabled={hasTasks}
-				outlined
-				label="Delete"
-				icon="pi pi-trash"
-				className="text-red-500 border-red-500 dark:text-red-400 dark:border-red-400 "
-				onClick={() => onDelete(category)}
-				tooltip={
-					hasTasks
-						? 'Cannot delete category while tasks are assigned.'
-						: undefined
-				}
-				tooltipOptions={tooltipOptions}
-			/>
-			<Button
-				label="Edit"
-				icon="pi pi-pencil"
-				outlined
-				onClick={() => onEdit(category)}
-				className="text-teal-700 border-teal-700 dark:text-teal-400 dark:border-teal-400"
-			/>
-		</div>
-	);
-
-	return (
-		<Card
-			title={header}
-			footer={footer}
-			subTitle={subTitle}
-			className="bg-white rounded-lg p-4 h-full justify-between border-2 border-gray-200 dark:border-0"
-		>
-			{content}
-		</Card>
 	);
 };
 

--- a/client/src/features/dashboard/Dashboard.tsx
+++ b/client/src/features/dashboard/Dashboard.tsx
@@ -10,8 +10,6 @@ import { useTasks } from '@queries';
 const Dashboard = () => {
 	const { data: tasks = [], isError, error, isLoading } = useTasks();
 
-	console.log(tasks);
-
 	if (isLoading)
 		return (
 			<div className="flex flex-row justify-center items-center min-h-screen">

--- a/client/src/features/tasks/Tasks.tsx
+++ b/client/src/features/tasks/Tasks.tsx
@@ -15,8 +15,6 @@ const Tasks = () => {
 	const { data: categories = [] } = useCategories();
 	const { data: tasks = [] } = useTasks();
 
-	console.log('tasks in tasks', tasks);
-
 	const confirmDelete = (selectedTasks: Task[]) => {
 		setTasksToDelete(selectedTasks);
 		setIsDeleteDialogVisible(true);

--- a/client/src/tests/Categories.spec.tsx
+++ b/client/src/tests/Categories.spec.tsx
@@ -151,7 +151,13 @@ describe('<Categories />', () => {
 
 		renderComponent();
 
-		await userEvent.click(screen.getAllByRole('button', { name: 'Edit' })[0]);
+		userEvent.click(screen.queryAllByLabelText('Options')[0]);
+
+		await waitFor(() => {
+			expect(screen.getByText('Edit')).toBeInTheDocument();
+		});
+
+		await userEvent.click(screen.getByText('Edit'));
 
 		expect(
 			screen.getByRole('dialog', { name: 'Edit Work category' })
@@ -179,8 +185,13 @@ describe('<Categories />', () => {
 
 		renderComponent();
 
-		await userEvent.click(screen.getAllByRole('button', { name: 'Delete' })[0]);
+		userEvent.click(screen.queryAllByLabelText('Options')[0]);
 
+		await waitFor(() => {
+			expect(screen.getByText('Delete')).toBeInTheDocument();
+		});
+
+		await userEvent.click(screen.getByText('Delete'));
 		await userEvent.click(screen.getByRole('button', { name: 'Yes' }));
 
 		await waitFor(() => expect(deleteCategory).toHaveBeenCalled());


### PR DESCRIPTION
## Changes:

- Moving position of the buttons Edit and Update in the Category card to the top right menu
- Removing Current tasks from the card to a separate dialog box that can be accessed from the menu button
- Adjusting UI and Unit tests

## Screen shots: 

![image](https://github.com/user-attachments/assets/28520478-2da6-4f97-b8fd-0cc98df2cd2a)

### When there are associated tasks with the Category, it can't be edited or deleted:

![image](https://github.com/user-attachments/assets/24047afa-f61f-4d39-8f0a-f64134df2bc4)

![image](https://github.com/user-attachments/assets/8a3297b6-d8ab-416f-98de-85c69088cb17)

### When there is no tasks associated with the Category, it can be edited or deleted:

![image](https://github.com/user-attachments/assets/d6dcebd5-754a-49fa-b817-7190c8d98f59)


### Dialog that lists the tasks assigned to the category:

![image](https://github.com/user-attachments/assets/8f19ea31-816c-450a-ac8a-687149dcd2bf)


### Responsiveness:

![image](https://github.com/user-attachments/assets/51f93c6c-60b3-4f26-b54c-1abf3c2ce099)


